### PR TITLE
Add Dockerfile for (many)linux wheel build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 *.pyc
+.eggs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
+/dist
 *.pyc
 .eggs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+ARG MANYLINUX=2010
+FROM quay.io/pypa/manylinux${MANYLINUX}_x86_64
+
+ARG PYTHON_VERSION=36
+ENV PYBIN /opt/python/cp${PYTHON_VERSION}-cp${PYTHON_VERSION}*/bin
+
+RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2-Linux-x86_64.tar.gz | tar xz -C /usr/ --strip-components=1 && \
+${PYBIN}/pip3 install -U pip auditwheel dqcsim 
+
+WORKDIR /io
+ENV DQCSIM_LIB /opt/python/cp36-cp36m/lib/libdqcsim.so
+ENV DQCSIM_INC /opt/python/cp36-cp36m/include
+ENTRYPOINT ["bash", "-c", "${PYBIN}/python3 setup.py bdist_wheel"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,12 @@ ARG PYTHON_VERSION=36
 ENV PYBIN /opt/python/cp${PYTHON_VERSION}-cp${PYTHON_VERSION}*/bin
 
 RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2-Linux-x86_64.tar.gz | tar xz -C /usr/ --strip-components=1 && \
-${PYBIN}/pip3 install -U pip auditwheel dqcsim 
+${PYBIN}/pip3 install -U pip auditwheel==3.0.0 dqcsim && \
+echo "214a215" > auditwheel.patch && \
+echo ">         remove_platforms = list(remove_platforms)" >> auditwheel.patch && \
+patch /opt/_internal/cpython-3.6.10/lib/python3.6/site-packages/auditwheel/wheeltools.py auditwheel.patch
 
-WORKDIR /io
 ENV DQCSIM_LIB /opt/python/cp36-cp36m/lib/libdqcsim.so
 ENV DQCSIM_INC /opt/python/cp36-cp36m/include
-ENTRYPOINT ["bash", "-c", "${PYBIN}/python3 setup.py bdist_wheel"]
+ADD . .
+ENTRYPOINT ["bash", "-c", "${PYBIN}/python3 setup.py bdist_wheel && ${PYBIN}/python3 -m auditwheel addtag -w /io/dist target/python/dist/*.whl"]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ package. It's just convenient to use it regardlessly. Install as follows:
 This allows you to use the `openql-mapper` operator in DQCsim, and exposes the
 `platform2gates` command (more on this in a bit).
 
-### Build/install from source using setup.py
+### Local build/install from source using setup.py
 
 This mimics a complete installation.
 
@@ -78,6 +78,9 @@ work:
 Now you can install:
 
     sudo pip3 install target/python/dist/*
+
+Note that this wheel should NOT be distributed as is; it will probably only
+work on your system. See release.md for info on complete release builds.
 
 ### Build from source using CMake
 

--- a/release.md
+++ b/release.md
@@ -1,0 +1,15 @@
+# Release process
+
+The release process is as follows:
+
+ - Update the version number in `setup.py`.
+ - Update the version number in `src/main.cpp`.
+ - Run `release.sh`. This will build the Python wheel in a manylinux docker
+   container and stick it in `dist/*.whl`.
+ - Install the wheel locally and test it with `setup.py test`.
+ - Push the wheel to PyPI with twine:
+
+```
+python3 -m pip install --user --upgrade twine
+python3 -m twine upload dist/*
+```

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+rm -rf dist
+
+docker build --pull -t dqcsim-openql-mapper-wheel . && \
+docker run -it --name dqcsim-openql-mapper-wheel dqcsim-openql-mapper-wheel && \
+docker cp dqcsim-openql-mapper-wheel:/io/dist/ .
+
+docker rm dqcsim-openql-mapper-wheel


### PR DESCRIPTION
```bash
docker build -t dqcsim-openql-mapper-wheel - < Dockerfile
docker run -it --rm -v `pwd`:/io dqcsim-openql-mapper-wheel
```
This outputs the wheel in `target/python/dist`. For now this is not running `addtag` yet.